### PR TITLE
Added a label to indicate the score increment compared to the previous run

### DIFF
--- a/scoreboard.lua
+++ b/scoreboard.lua
@@ -528,8 +528,15 @@ function mythicPlusBreakdown.RefreshBigBreakdownFrame()
             if (not color) then
                 color = _G["HIGHLIGHT_FONT_COLOR"]
             end
-            local textToFormat = "%d"
-            mainFrame.RantingLabel:SetText(color:WrapTextInColorCode(textToFormat:format(Details.LastMythicPlusData.NewDungeonScore or 0)))
+            local text = ""
+            if (gainedScore >= 1) then
+                local textToFormat = "%d (+%d)"
+                text = textToFormat:format(Details.LastMythicPlusData.NewDungeonScore, gainedScore)
+            else
+                local textToFormat = "%d"
+                text = textToFormat:format(Details.LastMythicPlusData.NewDungeonScore)
+            end
+            mainFrame.RantingLabel:SetText(color:WrapTextInColorCode(text))
             mainFrame.RantingLabel:SetTextColor(detailsFramework:ParseColors("limegreen"))
         else
             mainFrame.RantingLabel:SetText(playerRatingScore)


### PR DESCRIPTION
No increase:
![Wow_MQnifCbFM6](https://github.com/user-attachments/assets/548626c9-6fb3-4d07-9ed9-0de74d2c6a24)

With increase:
![Wow_CpgYwoM19V](https://github.com/user-attachments/assets/d77a5534-02f7-40cd-bc4d-1e8c3de32c91)

The check is set to a score of 1 or higher due to rounding of score and be consistent in showing it as digit instead of decimal