### PR TITLE
Some fixes and improvements

### DIFF
--- a/definitions.lua
+++ b/definitions.lua
@@ -7,18 +7,17 @@
 ---@class profile : table
 ---@field auto_open_mythic_plus_breakdown_big_frame boolean if true, the panel will open after x seconds after the m+ overall segment is ready.
 ---@field delay_to_open_mythic_plus_breakdown_big_frame number seconds to wait to open the big frame panel
+---@field show_column_summary_in_tooltip boolean whether or not to show the summary in a tooltip when hovering over the column
 ---@field font fontsettings font settings
 ---@field logs string[] logs of the addon
 ---@field logout_logs string[]
 
 ---@class fontsettings : table
----@field regular_size number
+---@field row_size number
 ---@field regular_color any
 ---@field regular_outline string
----@field hover_size number
 ---@field hover_color any
 ---@field hover_outline string
----@field standout_size number
 ---@field standout_color any
 ---@field standout_outline string
 

--- a/events.lua
+++ b/events.lua
@@ -43,19 +43,15 @@ function addon.InitializeEvents()
     end
 
     function addon.OnEncounterStart(...)
-        print("Encounter Start")
     end
 
     function addon.OnEncounterEnd(...)
-        print("Encounter End")
     end
 
     function addon.OnPlayerEnterCombat(...)
-        print("Player Enter")
     end
 
     function addon.OnPlayerLeaveCombat(...)
-        print("Player Leave")
     end
 
 end

--- a/start.lua
+++ b/start.lua
@@ -12,17 +12,17 @@ local tocFileName, private = ...
 local defaultSettings = {
     auto_open_mythic_plus_breakdown_big_frame = true,
     delay_to_open_mythic_plus_breakdown_big_frame = 5,
+    show_column_summary_in_tooltip = false,
     logs = {},
     font = {
-        regular_size = 12,
+        row_size = 12,
+
         regular_color = "white",
         regular_outline = "NONE",
 
-        hover_size = 12,
         hover_color = "orange",
         hover_outline = "NONE",
 
-        standout_size = 12,
         standout_color = {230/255, 204/255, 128/255},
         standout_outline = "NONE",
     },
@@ -41,6 +41,8 @@ function private.addon.OnInit(self, profile) --PLAYER_LOGIN
         profile.logout_logs = {}
     end
     self:SetLogoutLogTable(profile.logout_logs)
+
+    private.addon.data = {}
 
     local detailsEventListener = Details:CreateEventListener()
     private.addon.detailsEventListener = detailsEventListener


### PR DESCRIPTION
- Added show_column_summary_in_tooltip (off by default until tooltips are what we want them to be)
- hover_size and standout_size would cause issues if different from regular_size, so now they are all called row_size
- Added scoreboard_button:OnMouseEnter to make it possible to add a hover hook per column
- Added scoreboard_button:GetActor (actor, combat) to reduce duplicate code
- The main frame + row widths are dynamically calculated based on the amount of columns and their width
- Spike animation enabled
- CreateBreakdownButton uses a onMouseOver function instead of defining the attributes themselves]
- Verified that it automatically opens in M+