### PR TITLE
Keep track of the parsing state so we don't interact with events outside M+

### DIFF
--- a/definitions.lua
+++ b/definitions.lua
@@ -37,6 +37,7 @@
 ---@field OnPlayerLeaveCombat fun(...) run on COMBAT_PLAYER_LEAVE
 ---@field StartParser fun() start the combatlog parser
 ---@field StopParser fun() stop the combatlog parser
+---@field IsParsing fun():boolean whether or parsing at the moment
 ---@field OpenMythicPlusBreakdownBigFrame fun() open the mythic plus breakdown big frame
 ---@field MythicPlusOverallSegmentReady fun() executed after the run is done and details! has the m+ overall segment.
 ---@field CountInterruptOverlaps fun() executed after the run is done, count the interrupt overlaps for each player

--- a/events.lua
+++ b/events.lua
@@ -57,13 +57,17 @@ function addon.InitializeEvents()
     ---@field in_combat boolean whether the player is in combat or not
 
     function addon.OnPlayerEnterCombat(...)
-        local incombatTimeline = addon.profile.last_run_data.incombat_timeline
-        table.insert(incombatTimeline, {time = time(), in_combat = true})
+        if (addon.IsParsing()) then
+            local incombatTimeline = addon.profile.last_run_data.incombat_timeline
+            table.insert(incombatTimeline, {time = time(), in_combat = true})
+        end
     end
 
     function addon.OnPlayerLeaveCombat(...)
-        local incombatTimeline = addon.profile.last_run_data.incombat_timeline
-        table.insert(incombatTimeline, {time = time(), in_combat = false})
+        if (addon.IsParsing()) then
+            local incombatTimeline = addon.profile.last_run_data.incombat_timeline
+            table.insert(incombatTimeline, {time = time(), in_combat = false})
+        end
     end
 
 end

--- a/parser.lua
+++ b/parser.lua
@@ -19,6 +19,7 @@ local addon = private.addon
 ---@field used boolean
 
 local parserFrame = CreateFrame("frame")
+parserFrame.isParsing = false
 
 function addon.StartParser()
     print("+ Mythic Dungeon Start")
@@ -35,12 +36,18 @@ function addon.StartParser()
 
     parserFrame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
     parserFrame:SetScript("OnEvent", parserFrame.OnEvent)
+    parserFrame.isParsing = true
 end
 
 function addon.StopParser()
     print("- Mythic Dungeon Stopped")
     parserFrame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
     addon.CountInterruptOverlaps()
+    parserFrame.isParsing = false
+end
+
+function addon.IsParsing()
+    return parserFrame.isParsing
 end
 
 --functions for events that the addon is interesting in

--- a/scoreboard.lua
+++ b/scoreboard.lua
@@ -407,7 +407,7 @@ function mythicPlusBreakdown.RefreshBigBreakdownFrame()
                     spec = actorObject.spec,
                     role = actorObject.role or UnitGroupRolesAssigned(unitId),
                     score = rating,
-                    previousScore = Details.PlayerRatings[Details:GetFullName(unitId)] or rating - 100,
+                    previousScore = Details.PlayerRatings[Details:GetFullName(unitId)] or rating,
                     scoreColor = ratingColor,
                     deaths = deathAmount,
                     damageTaken = actorObject.damage_taken,


### PR DESCRIPTION
Solves the errors when not in M+:
```
2x Details_MythicPlus/events.lua:61: bad argument #1 to 'insert' (table expected, got nil)
2x Details_MythicPlus/events.lua:66: bad argument #1 to 'insert' (table expected, got nil)
```