### PR TITLE
Bunch of fixes and small things added

### DIFF
--- a/Details_MythicPlus.toc
+++ b/Details_MythicPlus.toc
@@ -15,3 +15,4 @@ scoreboard.lua
 events.lua
 functions.lua
 loot.lua
+slash.lua

--- a/definitions.lua
+++ b/definitions.lua
@@ -74,3 +74,5 @@
 ---@field GetBossKillTime fun(bossSegment:combat) : number retrieves the end time() of a boss encounter segment.
 ---@field CreateBossPortraitTexture fun(parent:frame, index:number) : bosswidget create a boss portrait texture widget
 ---@field IsScoreboardOpen fun() : boolean whether or not the scoreboard is shown in the screen
+---@field GetVersionString fun() : string the version info of just this addon
+---@field GetFullVersionString fun() : string the version info of details and this addon

--- a/options.lua
+++ b/options.lua
@@ -85,7 +85,7 @@ local optionsTemplate = {
 
 local mainFrameName = "DetailsMythicPlusOptionsFrame"
 
-function Details.ShowMythicPlusOptionsWindow()
+function addon.ShowMythicPlusOptionsWindow()
     mythicPlusOptions.ShowOptions()
 end
 

--- a/parser.lua
+++ b/parser.lua
@@ -30,12 +30,17 @@ function addon.StartParser()
 
     addon.data.interrupt_cast_overlap = {}
     addon.data.interrupt_cast_overlap_done = {}
+    addon.profile.last_run_data.run_start = time()
 
     parserFrame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
     parserFrame:SetScript("OnEvent", parserFrame.OnEvent)
     parserFrame.isParsing = true
 
     private.log("Parser stared")
+end
+
+function addon.GetLastRunStart()
+    return addon.profile.last_run_data.run_start or time()
 end
 
 function addon.StopParser()

--- a/scoreboard.lua
+++ b/scoreboard.lua
@@ -115,7 +115,7 @@ local mythicPlusBreakdown = {
     lines = {},
 }
 
-private.addon.mythicPlusBreakdown = mythicPlusBreakdown
+addon.mythicPlusBreakdown = mythicPlusBreakdown
 
 local GetItemInfo = GetItemInfo or C_Item.GetItemInfo
 local GetItemIcon = GetItemIcon or C_Item.GetItemIcon
@@ -263,7 +263,7 @@ function mythicPlusBreakdown.CreateBigBreakdownFrame()
     end)
     closeButton:SetPoint("topright", readyFrame, "topright", -4, -5)
 
-    local optionsButton = detailsFramework:CreateButton(readyFrame, Details.ShowMythicPlusOptionsWindow, 14, 14, "", nil, nil, nil, nil, "$parentOptionsButton", nil, nil)
+    local optionsButton = detailsFramework:CreateButton(readyFrame, addon.ShowMythicPlusOptionsWindow, 14, 14, "", nil, nil, nil, nil, "$parentOptionsButton", nil, nil)
     optionsButton:SetPoint("right", closeButton, "left", 0, 0)
     optionsButton:SetIcon([[Interface\Buttons\UI-OptionsButton]], 14, 14, nil, {0, 1, 0, 1}, nil, 3)
 
@@ -568,7 +568,7 @@ function mythicPlusBreakdown.RefreshBigBreakdownFrame()
             ---@type scoreboard_playerdata
             local playerData = data[i]
 
-            private.addon.loot.scoreboardLineCacheByName[playerData.name] = scoreboardLine
+            addon.loot.scoreboardLineCacheByName[playerData.name] = scoreboardLine
 
             --(re)set the line contents
             for j = 1, #frames do
@@ -584,7 +584,7 @@ function mythicPlusBreakdown.RefreshBigBreakdownFrame()
                     frame:SetPlayerData(playerData)
                 end
 
-                private.addon.loot.UpdateUnitLoot(scoreboardLine)
+                addon.loot.UpdateUnitLoot(scoreboardLine)
             end
 
             if (playerData) then

--- a/slash.lua
+++ b/slash.lua
@@ -1,0 +1,40 @@
+
+--functions to handle the slash commands
+---@type details
+local Details = _G.Details
+---@type detailsframework
+local detailsFramework = _G.DetailsFramework
+local addonName, private = ...
+---@type detailsmythicplus
+local addon = private.addon
+local _ = nil
+
+addon.commands = {
+    [""] = {"Open the options", function ()
+        print("Opening Details! Mythic+ scoreboard options, for more information use /sb help")
+        addon.ShowMythicPlusOptionsWindow()
+    end},
+    help = {"Shows this list of commands", function ()
+        print("available commands:")
+        local sb = WrapTextInColorCode("/sb ", "0000ccff")
+        for name, command in pairs(addon.commands) do
+            print(sb .. (name and WrapTextInColorCode(name .. " ", "001eff00") or "") .. command[1])
+        end
+    end},
+    version = {"Show the version", function ()
+        Details.ShowCopyValueFrame(addon.GetFullVersionString())
+    end},
+    open = {"Open the scoreboard", function ()
+        addon.OpenMythicPlusBreakdownBigFrame()
+    end}
+}
+
+SLASH_SCORE1, SLASH_SCORE2, SLASH_SCORE3 = "/scoreboard", "/score", "/sb"
+function SlashCmdList.SCORE(msg)
+    local command, rest = msg:match("^(%S*)%s*(.-)$")
+    command = string.lower(command)
+
+    if (addon.commands[command]) then
+        addon.commands[command][2](rest)
+    end
+end

--- a/start.lua
+++ b/start.lua
@@ -39,6 +39,14 @@ function private.addon.OnLoad(self, profile) --ADDON_LOADED
     --added has been loaded
 end
 
+function private.addon.GetVersionString()
+    return C_AddOns.GetAddOnMetadata("Details_MythicPlus", "Version")
+end
+
+function private.addon.GetFullVersionString()
+    return Details.GetVersionString() .. " | " .. private.addon.GetVersionString()
+end
+
 function private.addon.OnInit(self, profile) --PLAYER_LOGIN
     --logout logs register what happened to the addon when the player logged out
     if (not profile.logout_logs) then


### PR DESCRIPTION
- Hide boss widgets before creating new ones
- Fix highlight columns being 1 column too far to the left due to loot column being added
- Make damage taken mark the lowest instead of highest
- More aggressively hide icon labels on markers
- Save the last time a dungeon started and always use this time as dungeon started rather than relying on details segments, this way we force starting the timeline at that point rather than a potentially previous run
- Added a slash command: 
![image](https://github.com/user-attachments/assets/e49d759f-6195-46f5-bd56-807d629d5211)
