### PR TITLE
Different textures for dungeon completion

### DIFF
--- a/activityframe.lua
+++ b/activityframe.lua
@@ -38,6 +38,7 @@ function activity.UpdateBossWidgets(activityFrame, start, multiplier)
             local xPosition = killTimeRelativeToStart * multiplier
 
             bossWidget:SetPoint("bottomright", activityFrame, "bottomleft", xPosition, 4)
+            bossWidget:SetFrameLevel(10000 + i)
 
             bossWidget.TimeText:SetText(detailsFramework:IntegerToTimer(killTimeRelativeToStart))
 
@@ -88,4 +89,82 @@ function activity.ResetSegmentTextures(activityFrame)
     for i = 1, #activityFrame.segmentTextures do
         activityFrame.segmentTextures[i]:Hide()
     end
+end
+
+function activity.RenderDeathMarker(self, event, marker)
+    local preferUp = false
+    local playerPortrait = marker.subFrames.playerPortrait
+    ---@cast playerPortrait playerportrait
+    if (not marker.subFrames.playerPortrait) then
+        --player portrait
+        playerPortrait = Details:CreatePlayerPortrait(marker, "$parentPortrait")
+        ---@cast playerPortrait playerportrait
+        playerPortrait:ClearAllPoints()
+        playerPortrait:SetPoint("center", marker, "center", 0, 0)
+        playerPortrait.Portrait:SetSize(32, 32)
+        playerPortrait:SetSize(32, 32)
+        playerPortrait.RoleIcon:SetSize(18, 18)
+        playerPortrait.RoleIcon:ClearAllPoints()
+        playerPortrait.RoleIcon:SetPoint("bottomleft", playerPortrait.Portrait, "bottomright", -9, -2)
+
+        playerPortrait.Portrait:SetDesaturated(true)
+        playerPortrait.RoleIcon:SetDesaturated(true)
+
+        marker.subFrames.playerPortrait = playerPortrait
+    end
+
+    SetPortraitTexture(playerPortrait.Portrait, event.arguments.playerData.unitId)
+    local portraitTexture = playerPortrait.Portrait:GetTexture()
+    if (not portraitTexture) then
+        local class = event.arguments.playerData.class
+        playerPortrait.Portrait:SetTexture("Interface\\TargetingFrame\\UI-Classes-Circles")
+        playerPortrait.Portrait:SetTexCoord(unpack(CLASS_ICON_TCOORDS[class]))
+    end
+
+    local role = event.arguments.playerData.role
+    if (role == "TANK" or role == "HEALER" or role == "DAMAGER") then
+        playerPortrait.RoleIcon:SetAtlas(GetMicroIconForRole(role), TextureKitConstants.IgnoreAtlasSize)
+        playerPortrait.RoleIcon:Show()
+    else
+        playerPortrait.RoleIcon:Hide()
+    end
+
+    playerPortrait:SetFrameLevel(playerPortrait:GetParent():GetFrameLevel() - 2)
+    playerPortrait:Show()
+    playerPortrait.Portrait:Show()
+
+    detailsFramework:SetFontSize(marker.timestampLabel, 12)
+    detailsFramework:SetFontColor(marker.timestampLabel, 1, 0, 0)
+
+    return {
+        preferUp = preferUp,
+        forceDirection = nil,
+    }
+end
+
+function activity.RenderKeyFinishedMarker(self, event, marker)
+    local icon = marker.subFrames.icon
+    if (not icon) then
+        icon = marker:CreateTexture("$parentIcon", "artwork")
+        marker.subFrames.icon = icon
+    end
+
+    detailsFramework:SetFontSize(marker.timestampLabel, 12)
+    if (event.arguments.onTime) then
+        icon:SetAtlas("gficon-chest-evergreen-greatvault-collect")
+        detailsFramework:SetFontColor(marker.timestampLabel, 0.2, 0.8, 0.2)
+    else
+        icon:SetAtlas("gficon-chest-evergreen-greatvault-complete")
+        detailsFramework:SetFontColor(marker.timestampLabel, 0.8, 0.2, 0.2)
+    end
+
+    icon:SetSize(257*0.2, 226*0.2)
+    icon:ClearAllPoints()
+    icon:SetPoint("center", marker, "center", 0, 5)
+    icon:Show()
+
+    return {
+        preferUp = nil,
+        forceDirection = "up",
+    }
 end

--- a/definitions.lua
+++ b/definitions.lua
@@ -89,11 +89,22 @@
 ---@field GetBloodlustUsage fun() : number[]? retrieves the time() in seconds when the player received bloodlust buff.
 ---@field GetLastRunStart fun() : number retrieves the time() when the last run started
 
+---@class activitytimeline_marker : frame
+---@field subFrames frame[]
+---@field timestampLabel frame
+---@field lineTexture frame
+
+---@class activitytimeline_marker_data : table
+---@field forceDirection string|nil up or down
+---@field preferUp boolean|nil when true it will initially try to render above the timeline
+
 ---@class activitytimeline : table
 ---@field UpdateBossWidgets fun(self:scoreboard_activityframe, start:number, multiplier:number) update the boss widgets showing the kill time of each boss
 ---@field UpdateBloodlustWidgets fun(self:scoreboard_activityframe, start:number, multiplier:number) update the bloodlust widgets showing the time of bloodlust usage
 ---@field ResetSegmentTextures fun(self:scoreboard_activityframe) reset the next index of texture to use and hide all existing textures
 ---@field GetSegmentTexture fun(self:scoreboard_activityframe) : texture return a texture to be used as a segment of the activity bar
+---@field RenderKeyFinishedMarker fun(self:scoreboard_activityframe, event:timeline_event, marker:activitytimeline_marker) : activitytimeline_marker_data
+---@field RenderDeathMarker fun(self:scoreboard_activityframe, event:timeline_event, marker:activitytimeline_marker) : activitytimeline_marker_data
 
 ---@class scoreboard_activityframe : frame
 ---@field nextTextureIndex number
@@ -102,4 +113,4 @@
 ---@field InCombatTexture texture
 ---@field OutOfCombatTexture texture
 ---@field BackgroundTexture texture
----@field SetActivity fun(self: scoreboard_activityframe, events: table<number, timeline_event>, inCombat: number, outOfCombat: number)
+---@field SetActivity fun(self: scoreboard_activityframe, events: timeline_event[], inCombat: number, outOfCombat: number)

--- a/frames.lua
+++ b/frames.lua
@@ -30,14 +30,15 @@ function addon.CreateBossPortraitTexture(parent, index)
     bossAvatar:SetScale(1.0)
     newBossWidget.AvatarTexture = bossAvatar
 
-    local verticalLine = detailsFramework:CreateImage(newBossWidget, "", 1, 25, "overlay")
-    verticalLine:SetColorTexture(1, 1, 1, 0.3)
-    verticalLine:SetPoint("bottomleft", newBossWidget, "bottomright", 0, 0)
-    newBossWidget.VerticalLine = verticalLine
-
     local timeText = detailsFramework:CreateLabel(newBossWidget)
     timeText:SetPoint("bottomright", newBossWidget, "bottomright", 0, 0)
     newBossWidget.TimeText = timeText
+
+    local verticalLine = detailsFramework:CreateImage(newBossWidget, "", 1, 25, "overlay")
+    verticalLine:SetColorTexture(1, 1, 1, 0.3)
+    verticalLine:SetPoint("bottomleft", newBossWidget, "bottomright", 0, 0)
+    verticalLine:SetPoint("topleft", timeText, "topright", 0, 0)
+    newBossWidget.VerticalLine = verticalLine
 
     local timeBackground = detailsFramework:CreateImage(newBossWidget, "", 30, 12, "artwork")
     timeBackground:SetColorTexture(0, 0, 0, 0.8)


### PR DESCRIPTION
- Using the vault icons for dungeon completion, where a grey vault is untimed
- Moved the +1, +2, +3 to behind the dungeon name
- Increased the boss segments frame level to prevent being rendered too low
- Reduced the reserved space for markers by 10% on each side to allow for a small overlap