### PR TITLE
Save the map id in the last_run_data

### DIFF
--- a/definitions.lua
+++ b/definitions.lua
@@ -172,6 +172,7 @@
 ---@field standout_outline string
 
 ---@class detailsmythicplus_run_data : table
+---@field map_id number
 ---@field start_time number
 ---@field end_time number
 ---@field incombat_timeline detailsmythicplus_combatstep[] first table tells the group left table, second when entered in combat, third when left combat, and so on

--- a/events.lua
+++ b/events.lua
@@ -53,6 +53,7 @@ function addon.InitializeEvents()
 
     function addon.OnMythicDungeonStart(...)
         addon.profile.last_run_data.start_time = time()
+        addon.profile.last_run_data.map_id = Details.challengeModeMapId or C_ChallengeMode.GetActiveChallengeMapID()
         --store the first value in the in combat timeline.
         addon.profile.last_run_data.incombat_timeline = {{time = time(), in_combat = false}}
         addon.profile.last_run_data.encounter_timeline = {}

--- a/rundata.lua
+++ b/rundata.lua
@@ -65,7 +65,7 @@ function addon.CreateRunInfo(mythicPlusOverallSegment)
         timeLimit = 0, --done
         startTime = addon.profile.last_run_data.start_time,
         endTime = time(),
-        mapId = completionInfo.mapChallengeModeID or Details.challengeModeMapId or C_ChallengeMode.GetActiveChallengeMapID(),
+        mapId = completionInfo.mapChallengeModeID or addon.profile.last_run_data.map_id,
     }
 
     local dungeonName, id, timeLimit, texture, backgroundTexture = C_ChallengeMode.GetMapUIInfo(runInfo.mapId)


### PR DESCRIPTION
The mythic dungeon completion event can trigger while outside of the dungeon, I suspect that causes the current challenge to fail when the dungeon is reset