### PR TITLE
Reject possibly broken runs and try to fix upon startup

### DIFF
--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -56,6 +56,7 @@ do
     L["SCOREBOARD_TOOLTIP_INTERRUPT_OVERLAP_LABEL"] = "Overlap"
     L["SCOREBOARD_TOOLTIP_INTERRUPT_MISSED_LABEL"] = "Missed"
     L["SCOREBOARD_TOOLTIP_INTERRUPT_TOTAL_LABEL"] = "Total interrupts"
+    L["ADDON_STARTUP_REMOVED_CORRUPT_HISTORY"] = "Removed %d corrupt run(s) from history."
 
     ------------------------------------------------------------
     --@localization(locale="enUS", format="lua_additive_table")@

--- a/rundata.lua
+++ b/rundata.lua
@@ -21,6 +21,11 @@ local L = detailsFramework.Language.GetLanguageTable(addonName)
 ---runs on details! event COMBAT_MYTHICPLUS_OVERALL_READY
 function addon.CreateRunInfo(mythicPlusOverallSegment)
     local completionInfo = C_ChallengeMode.GetChallengeCompletionInfo()
+    if (completionInfo.mapChallengeModeID == 0) then
+        private.log("Missing completionInfo.mapChallengeModeID, possibly due to and error or reload after the key completed")
+        return
+    end
+
     local combatTime = mythicPlusOverallSegment:GetCombatTime()
 
     --debug

--- a/start.lua
+++ b/start.lua
@@ -129,6 +129,26 @@ function addon.OnInit(self, profile) --PLAYER_LOGIN
 
     -- fix/migrate settings
 
+    -- always show the last run first
+    addon.profile.saved_runs_selected_index = 1
+
+    -- try to yeet broken saves
+    local totalRuns = #addon.profile.saved_runs
+    local fixedRuns = {}
+    for i = 1, totalRuns do
+        local run = addon.profile.saved_runs[i]
+        if (run and run.completionInfo and run.completionInfo.mapChallengeModeID ~= 0) then
+            fixedRuns[#fixedRuns + 1]  = run
+        end
+    end
+
+    local delta = totalRuns - #fixedRuns
+    if (delta > 0) then
+        print("Details! Mythic+: " .. string.format(L["ADDON_STARTUP_REMOVED_CORRUPT_HISTORY"], delta))
+    end
+
+    addon.profile.saved_runs = fixedRuns
+
     -- ensure people don't break the scale
     addon.profile.scoreboard_scale = math.max(0.6, math.min(1.6, addon.profile.scoreboard_scale))
 


### PR DESCRIPTION
Not sure what caused this, I suspect a reload after my dungeon run. I also had an issue where it looked like I was dc'd, but wasn't. Chat was working, including messages of people leaving or joining my group, but I couldn't gracefully exit the game.

This will just attempt to cleanup any datacorruption so it won't break randomly for people in those scenarios.