### PR TITLE
Reduced saved vars storage size by ~2.5x

### DIFF
--- a/Details_MythicPlus.toc
+++ b/Details_MythicPlus.toc
@@ -32,3 +32,4 @@ events.lua
 functions.lua
 slash.lua
 rundata.lua
+migrations.lua

--- a/definitions.lua
+++ b/definitions.lua
@@ -39,6 +39,8 @@
 ---@field scoreboard_scale number indicates the scale of the scoreboard window
 ---@field translit boolean translit cyrillic
 ---@field last_run_data detailsmythicplus_run_data store the data from the last run
+---@field keep_information_for_debugging boolean keep certain information for debugging
+---@field migrations_done number the timestamp of when a migration was done, where the key is the migration number from migrations.lua
 ---@field font fontsettings font settings
 ---@field logs string[] logs of the addon
 ---@field logout_logs string[]
@@ -49,6 +51,7 @@
 ---@field loot loot
 ---@field data table store data from the current mythic plus run
 ---@field Enum enum
+---@field Migrations table<number, fun()>
 ---@field selectedRunInfo runinfo currently run info in use (showing the data in the scoreboard), if any
 ---@field mythicPlusBreakdown details_mythicplus_breakdown
 ---@field activityTimeline activitytimeline namespace for functions related to the activity timeline
@@ -96,7 +99,7 @@
 ---@field combatId number the dungeon overall data unique combat id from details!
 ---@field combatData combatdata stores the required combat data for the score board, hence the scoreboard can function even if the combat isn't available in details!
 ---@field encounters detailsmythicplus_encounterinfo[] the encounters timeline
----@field combatTimeline detailsmythicplus_combatstep[] the combat timeline
+---@field combatTimeline number[] the combat timeline
 ---@field completionInfo challengemodecompletioninfo
 ---@field timeWithoutDeaths number total time in seconds the run took without counting the time lost by player deaths
 ---@field timeInCombat number total time in seconds the run took in combat
@@ -179,19 +182,13 @@
 ---@field map_id number
 ---@field start_time number
 ---@field end_time number
----@field incombat_timeline detailsmythicplus_combatstep[] first table tells the group left table, second when entered in combat, third when left combat, and so on
+---@field incombat_timeline number[] first time is no combat (key start), then every timestamp is a toggle
 ---@field encounter_timeline detailsmythicplus_encounterinfo[] store the data from encounter_start and encounter_end events, one sub table per boss attempt
 ---@field interrupt_overlaps table<string, number> count the interrupt overlaps for each player
-
----@class detailsmythicplus_combatstep : table a table with the time and if the group was in combat or not, sub table of 'incombat_timeline'
----@field time number time() of when the player entered or left combat
----@field in_combat boolean whether the player is in combat or not
 
 ---@class detailsmythicplus_encounterinfo : table
 ---@field dungeonEncounterId number encounter id given from the encounter_start event
 ---@field encounterName string localized name of the encounter
----@field difficultyId number difficulty id of the encounter
----@field raidSize number number of players in the group
 ---@field startTime number time() of when the encounter started
 ---@field endTime number time() of when the encounter ended (if the encounter did not ended yet, this value is zero)
 ---@field defeated boolean true if the boss has been killed

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -41,6 +41,9 @@ do
     L["OPTIONS_SHOW_TIME_SECTIONS_DESC"] = "Shows time labels for sections on the timeline as a guide"
     L["OPTIONS_SHOW_REMAINING_TIME_LABEL"] = "Show remaining time"
     L["OPTIONS_SHOW_REMAINING_TIME_DESC"] = "When a key is timed, an extra section will be added showing the time still remaining"
+    L["OPTIONS_DEBUG"] = "Debug"
+    L["OPTIONS_DEBUG_STORE_DEBUG_INFO_LABEL"] = "Save debug info"
+    L["OPTIONS_DEBUG_STORE_DEBUG_INFO_DESC"] = "Enabling this option will save more information when reloading for debugging purposes. It is recommended to keep this option off unless you are actually debugging"
 
     L["SCOREBOARD_NO_SCORE_AVAILABLE"] = "There is currently no score on the board"
     L["SCOREBOARD_TITLE_PLAYER_NAME"] = "Player Name"

--- a/migrations.lua
+++ b/migrations.lua
@@ -1,0 +1,30 @@
+local addonName, private = ...
+---@type detailsmythicplus
+local addon = private.addon
+
+addon.Migrations = {
+    function ()
+        -- structure was changed to use just numbers instead of a table with extra info
+        for _, run in pairs(addon.profile.saved_runs) do
+            for i, timeline in pairs(run.combatTimeline) do
+                run.combatTimeline[i] = timeline.time
+            end
+        end
+    end,
+
+    function ()
+        -- structure was changed to only store the last 7
+        for _, run in pairs(addon.profile.saved_runs) do
+            for _, damageTakenList in pairs(run.combatData.groupMembers) do
+                local newDamageTakeFromSpells = {}
+                for i, damageTaken in pairs(damageTakenList.damageTakenFromSpells) do
+                    if (i > 7) then
+                        break
+                    end
+                    newDamageTakeFromSpells[i] = damageTaken
+                end
+                damageTakenList.damageTakenFromSpells = newDamageTakeFromSpells
+            end
+        end
+    end,
+}

--- a/options.lua
+++ b/options.lua
@@ -28,6 +28,9 @@ local orange_font_template = detailsFramework:GetTemplate("font", "ORANGE_FONT_T
 local mythicPlusOptions = {}
 
 local optionsTemplate = {
+    ---
+    --- General Options
+    ---
     {type = "label", get = function() return L["OPTIONS_GENERAL_OPTIONS"] end, text_template = orange_font_template},
     {
         type = "select",
@@ -88,6 +91,10 @@ local optionsTemplate = {
         name = L["OPTIONS_TRANSLIT_LABEL"],
         desc = L["OPTIONS_TRANSLIT_DESC"],
     },
+
+    ---
+    --- Saving options
+    ---
     {type = "label", get = function() return L["OPTIONS_SAVING"] end, text_template = orange_font_template},
     {
         type = "range",
@@ -102,6 +109,10 @@ local optionsTemplate = {
         name = L["OPTIONS_HISTORY_RUNS_TO_KEEP_LABEL"],
         desc = L["OPTIONS_HISTORY_RUNS_TO_KEEP_DESC"],
     },
+
+    ---
+    --- Timeline Options
+    ---
     {type = "label", get = function() return L["OPTIONS_SECTION_TIMELINE"] end, text_template = orange_font_template},
     {
         type = "toggle",
@@ -122,6 +133,21 @@ local optionsTemplate = {
         end,
         name = L["OPTIONS_SHOW_REMAINING_TIME_LABEL"],
         desc = L["OPTIONS_SHOW_REMAINING_TIME_DESC"],
+    },
+
+    ---
+    --- Debug options
+    ---
+    {type = "label", get = function() return L["OPTIONS_DEBUG"] end, text_template = orange_font_template},
+    {
+        type = "toggle",
+        get = function () return addon.profile.keep_information_for_debugging end,
+        set = function (_, _, value)
+            addon.profile.keep_information_for_debugging = value
+            addon.RefreshOpenScoreBoard()
+        end,
+        name = L["OPTIONS_DEBUG_STORE_DEBUG_INFO_LABEL"],
+        desc = L["OPTIONS_DEBUG_STORE_DEBUG_INFO_DESC"],
     },
 }
 

--- a/options.lua
+++ b/options.lua
@@ -171,9 +171,9 @@ function mythicPlusOptions.InitializeOptionsWindow()
     detailsFramework:MakeDraggable(optionsFrame)
     optionsFrame:SetPoint("center", UIParent, "center", 160, -50)
     detailsFramework:ApplyStandardBackdrop(optionsFrame)
-    optionsFrame:SetFrameStrata("HIGH")
+    optionsFrame:SetFrameStrata("DIALOG")
     optionsFrame:SetToplevel(true)
-    optionsFrame:SetFrameLevel(1000)
+    optionsFrame:SetFrameLevel(5)
 
     --close button at the top right of the frame
     local closeButton = detailsFramework:CreateCloseButton(optionsFrame, "$parentCloseButton")

--- a/rundata.lua
+++ b/rundata.lua
@@ -59,7 +59,6 @@ function addon.CreateRunInfo(mythicPlusOverallSegment)
             isEligibleForScore = completionInfo.isEligibleForScore,
             isMapRecord = completionInfo.isMapRecord,
             isAffixRecord = completionInfo.isAffixRecord,
-            members = completionInfo.members,
         },
         encounters = detailsFramework.table.copy({}, addon.profile.last_run_data.encounter_timeline),
         combatTimeline = detailsFramework.table.copy({}, addon.profile.last_run_data.incombat_timeline),
@@ -92,6 +91,13 @@ function addon.CreateRunInfo(mythicPlusOverallSegment)
 
         if (actorObject:IsPlayer()) then
             local unitName = actorObject:Name()
+            local damageTakenFromSpells = {}
+            for i, damageTaken in pairs(mythicPlusOverallSegment:GetDamageTakenBySpells(unitName)) do
+                if (i > 7) then
+                    break
+                end
+                table.insert(damageTakenFromSpells, damageTaken)
+            end
 
             ---@type playerinfo
             local playerInfo = {
@@ -115,9 +121,9 @@ function addon.CreateRunInfo(mythicPlusOverallSegment)
                 totalInterruptsCasts = 0,
                 totalCrowdControlCasts = 0,
                 healDoneBySpells = {}, --done
-                damageTakenFromSpells  = mythicPlusOverallSegment:GetDamageTakenBySpells(unitName),
-                damageDoneBySpells  = {}, --done
-                dispelWhat  = {}, --done
+                damageTakenFromSpells = damageTakenFromSpells,
+                damageDoneBySpells = {}, --done
+                dispelWhat = {}, --done
                 interruptWhat = {}, --done
                 interruptCastOverlapDone = addon.profile.last_run_data.interrupt_cast_overlap_done[unitName] or 0,
                 crowdControlSpells = {}, --done

--- a/scoreboard.lua
+++ b/scoreboard.lua
@@ -802,7 +802,6 @@ local showCrowdControlTooltip = function(self)
         local spellInfo = C_Spell.GetSpellInfo(spellName)
         if (spellInfo) then
             GameCooltip:AddIcon(spellInfo.iconID, 1, 1, 16, 16)
-        else
         end
     end
 
@@ -1107,11 +1106,10 @@ function mythicPlusBreakdown.CreateLineForBigBreakdownFrame(mainFrame, headerFra
             local spellsThatHitThisPlayer = playerData.damageTakenFromSpells
 
             GameCooltip:Preset(2)
-
-            for i = 1, math.min(#spellsThatHitThisPlayer, 7) do
-                local spellId = spellsThatHitThisPlayer[i].spellId
-                local amount = spellsThatHitThisPlayer[i].amount
-                local sourceName = spellsThatHitThisPlayer[i].damagerName
+            for _, spellData in pairs(spellsThatHitThisPlayer) do
+                local spellId = spellData.spellId
+                local amount = spellData.amount
+                local sourceName = spellData.damagerName
 
                 local spellName, _, spellIcon = Details.GetSpellInfo(spellId)
                 if (spellName and spellIcon) then
@@ -1280,19 +1278,19 @@ function mythicPlusBreakdown.CreateActivityPanel(mainFrame)
             leave_combat = {0.7, 0.1, 0.1, 0.5},
         }
 
-        ---@type detailsmythicplus_combatstep[]
+        ---@type number[]
         local combatTimeline = runData.combatTimeline
         local timestamps = {}
         local last
         for i = 1, #combatTimeline do
-            local timestamp = combatTimeline[i].time
+            local timestamp = combatTimeline[i]
             if (timestamp >= runData.startTime) then
                 last = {
                     time = timestamp - runData.startTime,
-                    event = combatTimeline[i].in_combat and "enter_combat" or "leave_combat"
+                    event = i % 2 == 0 and "enter_combat" or "leave_combat"
                 }
 
-                timestamps[#timestamps+1] = last
+                table.insert(timestamps, last)
             end
         end
 

--- a/start.lua
+++ b/start.lua
@@ -23,6 +23,8 @@ local defaultSettings = {
     saved_runs_selected_index = 1,
     scoreboard_scale = 1.0,
     translit = GetLocale() ~= "ruRU",
+    keep_information_for_debugging = false,
+    migrations_done = {},
     logs = {},
     font = {
         row_size = 12,
@@ -127,8 +129,6 @@ function addon.OnInit(self, profile) --PLAYER_LOGIN
         end,
     })
 
-    -- fix/migrate settings
-
     -- always show the last run first
     addon.profile.saved_runs_selected_index = 1
 
@@ -164,6 +164,14 @@ function addon.OnInit(self, profile) --PLAYER_LOGIN
     -- required to create early due to the frame events
     local scoreboard = addon.CreateBigBreakdownFrame()
     scoreboard:SetScale(addon.profile.scoreboard_scale)
+
+    -- run migrations
+    for i, migration in pairs(addon.Migrations) do
+        if (not addon.profile.migrations_done[i]) then
+            migration()
+            addon.profile.migrations_done[i] = time()
+        end
+    end
 
     private.log("addon loaded")
 end


### PR DESCRIPTION
- Combat steps are now just timestamps, where it implicitly means that the first stamp is no combat, then the second stamp turns combat on, third turns it off again etc.
- Now only storing the top 7 spells for damage taken, which greatly reduces the amount of tables being saved
- Added migrations. It will only run each migration once and save the time when it ran. It's up to the migration itself to be smart and see if it actually needs to migrate or not.
- Added an option to not clear storage information at the end of the dungeon, but keep it in the last_run_data until the next run starts

