### PR TITLE
Fix zoomed in player portraits

### DIFF
--- a/activityframe.lua
+++ b/activityframe.lua
@@ -158,6 +158,7 @@ function activity.RenderDeathMarker(frame, event, marker)
 
     SetPortraitTexture(playerPortrait.Portrait, event.arguments.playerData.unitId)
     local portraitTexture = playerPortrait.Portrait:GetTexture()
+    playerPortrait.Portrait:SetTexCoord(0, 0, 0, 1, 1, 0, 1, 1)
     if (not portraitTexture) then
         local class = event.arguments.playerData.class
         playerPortrait.Portrait:SetTexture("Interface\\TargetingFrame\\UI-Classes-Circles")

--- a/scoreboard.lua
+++ b/scoreboard.lua
@@ -635,12 +635,12 @@ function mythicPlusBreakdown.RefreshBigBreakdownFrame(mainFrame, runData)
 
             if (playerData) then
                 scoreboardLine:Show()
-                --dumpt(playerData)
                 local playerPortrait = frames[1]
                 local specIcon = frames[2]
 
                 SetPortraitTexture(playerPortrait.Portrait, playerData.unitId)
                 local portraitTexture = playerPortrait.Portrait:GetTexture()
+                playerPortrait.Portrait:SetTexCoord(0, 0, 0, 1, 1, 0, 1, 1)
                 if (not portraitTexture) then
                     local class = playerData.class
                     playerPortrait.Portrait:SetTexture("Interface\\TargetingFrame\\UI-Classes-Circles")


### PR DESCRIPTION
Due to portraits beings re-used, it would never reset the texture coordinates after being a class icon once