### PR TITLE
Don't add 0 to the average ilvl when unknown

### DIFF
--- a/rundata.lua
+++ b/rundata.lua
@@ -393,10 +393,19 @@ end
 ---@return number
 function addon.GetRunAverageItemLevel(runInfo)
     local total = 0
+    local players = 0
     for _, playerInfo in pairs(runInfo.combatData.groupMembers) do
-        total = total + playerInfo.ilevel
+        if (playerInfo.ilevel > 0) then
+            total = total + playerInfo.ilevel
+            players = players + 1
+        end
     end
-    return total / 5
+
+    if (players == 0) then
+        return 0
+    end
+
+    return total / players
 end
 
 ---return the average damage per second

--- a/scoreboard.lua
+++ b/scoreboard.lua
@@ -230,7 +230,7 @@ local SaveLoot = function(itemLink, unitName)
 
     local effectiveILvl, _, baseItemLevel = C_Item.GetDetailedItemLevelInfo(itemLink)
     local averageItemLevel = addon.GetRunAverageItemLevel(lastRun)
-    if (effectiveILvl < averageItemLevel * 0.75 or baseItemLevel < 6) then
+    if (effectiveILvl < averageItemLevel * 0.69 or baseItemLevel < 6) then
         return
     end
 


### PR DESCRIPTION
and slightly lower the ilvl threshold for loot to show up as the squish _may_ overlap in the lowest keys when ilvls of the party are unknown and averages out too high.