### PR TITLE
Fixes the score being 0

### DIFF
--- a/dummytails.lua
+++ b/dummytails.lua
@@ -38,28 +38,26 @@ function private.GetKeystoneInfo(playerName)
         end
     end
 
-    if PlayerInfo then
-        local playerInfo = GetPlayerInfo(playerName)
-        if playerInfo then
-            local keystoneInfo = playerInfo.keystoneInfo
-            if keystoneInfo then
-                returnTable.keystoneLevel = keystoneInfo.level
-                returnTable.keystoneMapId = keystoneInfo.mythicPlusMapID
-                returnTable.rating = keystoneInfo.rating
-                ---@type details_instanceinfo
-                local instanceInfo = private.Details:GetInstanceInfo(keystoneInfo.mapID)
-                if (instanceInfo) then
-                    returnTable.keystoneIcon = instanceInfo.iconLore
-                end
-
-                --keystoneInfo.level
-                --keystoneInfo.mapID
-                --keystoneInfo.challengeMapID
-                --keystoneInfo.classID
-                --keystoneInfo.rating
-                --keystoneInfo.mythicPlusMapID
-                --keystoneInfo.specID
+    local playerInfo = GetPlayerInfo(playerName)
+    if playerInfo then
+        local keystoneInfo = playerInfo.keystoneInfo
+        if keystoneInfo then
+            returnTable.keystoneLevel = keystoneInfo.level
+            returnTable.keystoneMapId = keystoneInfo.mythicPlusMapID
+            returnTable.rating = keystoneInfo.rating
+            ---@type details_instanceinfo
+            local instanceInfo = private.Details:GetInstanceInfo(keystoneInfo.mapID)
+            if (instanceInfo) then
+                returnTable.keystoneIcon = instanceInfo.iconLore
             end
+
+            --keystoneInfo.level
+            --keystoneInfo.mapID
+            --keystoneInfo.challengeMapID
+            --keystoneInfo.classID
+            --keystoneInfo.rating
+            --keystoneInfo.mythicPlusMapID
+            --keystoneInfo.specID
         end
     end
 

--- a/libs/PlayerInfo/PlayerInfo.lua
+++ b/libs/PlayerInfo/PlayerInfo.lua
@@ -835,6 +835,10 @@ local getPlayerInfo = function(playerName)
 
         if (gameVersionHasMythicPlus()) then
             thisPlayerInfo.keystoneInfo = CopyTable(keystoneTablePrototype)
+            local summary = C_PlayerInfo.GetPlayerMythicPlusRatingSummary(playerName)
+            if (summary and summary.currentSeasonScore) then
+            	thisPlayerInfo.keystoneInfo.rating = summary.currentSeasonScore
+            end
         end
 
         playerInfoDatabase[playerName] = thisPlayerInfo

--- a/rundata.lua
+++ b/rundata.lua
@@ -155,21 +155,13 @@ function addon.CreateRunInfo(mythicPlusOverallSegment)
                 deathEvents = {}, --information about when the player died
                 deathLastHits = {}, --information for the tooltip when the player died
                 likedBy = {},
+                score = C_PlayerInfo.GetPlayerMythicPlusRatingSummary(unitName).currentSeasonScore,
+                scorePrevious = private.PlayerRatings[unitName] or 0,
+                activityTimeDamage = actorObject:Tempo(),
+                totalDeaths = #mythicPlusOverallSegment:GetPlayerDeaths(unitName),
             }
 
             runInfo.combatData.groupMembers[unitName] = playerInfo
-
-            if (type(actorObject.mrating) == "table") then
-                actorObject.mrating = actorObject.mrating.currentSeasonScore
-            end
-            local score = actorObject.mrating or 0
-            playerInfo.score = score
-            playerInfo.scorePrevious = private.PlayerRatings[unitName] or score
-
-            playerInfo.activityTimeDamage = actorObject:Tempo()
-
-            local playerDeaths = mythicPlusOverallSegment:GetPlayerDeaths(unitName)
-            playerInfo.totalDeaths = #playerDeaths
 
             local deathTable = mythicPlusOverallSegment:GetDeaths()
             for i = 1, #deathTable do


### PR DESCRIPTION
This is likely not the best fix, but it does work. The underlying 2 problems:
- `PlayerInfo`  was not defined, so it would never fetch the info if the user didn't use open raid lib
- The M+ score would only be obtained through comms. If the other players aren't using PlayerInfo or OpenRaidLib, the m+ score would never be filled. This change uses the Blizzard API to pre-fill it, and the rundata no longer fetches it from details

