### PR TITLE
Improve compatibility when running without details (no open raid lib or player info lib)

### DIFF
--- a/definitions.lua
+++ b/definitions.lua
@@ -252,6 +252,7 @@
 ---@field interrupt_overlaps table<string, number> count the interrupt overlaps for each player
 ---@field interrupt_spells_cast table<string, table>
 ---@field interrupt_cast_overlap_done table<string, number> interrupts per player
+---@field player_ratings table<string, number> ratings per player
 ---@field reloaded boolean whether or not the run had a reload in-between
 
 ---@class detailsmythicplus_encounterinfo : table

--- a/dummytails.lua
+++ b/dummytails.lua
@@ -61,7 +61,7 @@ function private.GetKeystoneInfo(playerName)
         end
     end
 
-    if (not returnTable.rating) then
+    if (not returnTable.rating or returnTable.rating == 0) then
     	local keystoneSummary = C_PlayerInfo.GetPlayerMythicPlusRatingSummary(playerName)
         returnTable.rating = keystoneSummary and keystoneSummary.currentSeasonScore
     end

--- a/events.lua
+++ b/events.lua
@@ -127,6 +127,7 @@ function addon.InitializeEvents()
         addon.profile.last_run_data.encounter_timeline = {}
         addon.profile.last_run_data.interrupt_spells_cast = {}
         addon.profile.last_run_data.interrupt_cast_overlap_done = {}
+        addon.profile.last_run_data.player_ratings = CopyTable(private.PlayerRatings)
 
         addon.StartParser()
 

--- a/rundata.lua
+++ b/rundata.lua
@@ -120,6 +120,16 @@ function addon.CreateRunInfo(mythicPlusOverallSegment)
 
             local guid = actorObject:GetGUID()
 
+			local summary = C_PlayerInfo.GetPlayerMythicPlusRatingSummary(unitName)
+			local currentScore = summary and summary.currentSeasonScore
+			local previousScore = addon.profile.last_run_data.player_ratings[unitName] or 0
+
+			if (previousScore == 0 and currentScore > 450) then
+				-- in case there's an issue and the actual score is incorrectly set to 0
+				-- it'll show "1530" instead of "1530 (+1530)"
+				previousScore = currentScore
+			end
+
             ---@type playerinfo
             local playerInfo = {
                 name = unitName,
@@ -155,8 +165,8 @@ function addon.CreateRunInfo(mythicPlusOverallSegment)
                 deathEvents = {}, --information about when the player died
                 deathLastHits = {}, --information for the tooltip when the player died
                 likedBy = {},
-                score = C_PlayerInfo.GetPlayerMythicPlusRatingSummary(unitName).currentSeasonScore,
-                scorePrevious = private.PlayerRatings[unitName] or 0,
+                score = currentScore,
+                scorePrevious = previousScore,
                 activityTimeDamage = actorObject:Tempo(),
                 totalDeaths = #mythicPlusOverallSegment:GetPlayerDeaths(unitName),
             }

--- a/scoreboard.lua
+++ b/scoreboard.lua
@@ -586,6 +586,12 @@ function mythicPlusBreakdown.RefreshScoreboardFrame(mainFrame, runData)
                 ratingColor = _G["HIGHLIGHT_FONT_COLOR"]
             end
 
+			if (playerInfo.scorePrevious == 0 and score > 450) then
+				-- in case there's an issue and the actual score is incorrectly set to 0
+				-- it'll show "1530" instead of "1530 (+1530)"
+				playerInfo.scorePrevious = score
+			end
+
             ---@type scoreboard_playerdata
             local thisPlayerData = {
                 runId = runData.runId,


### PR DESCRIPTION
- Fixed when no Open Raid Lib and no PlayerInfo is available from other players (when using without Details! installed)
- Try to restore previous scores after reload by saving it in the profile for this run